### PR TITLE
Fix escape codes regex

### DIFF
--- a/src/TextWrap.jl
+++ b/src/TextWrap.jl
@@ -12,7 +12,7 @@ export
     print_wrapped,
     println_wrapped
 
-ansi_length(s) = length(replace(s, r"\e\[[0-9]+m" => ""))
+ansi_length(s) = length(replace(s, r"\e\[[0-9]+(?:;[0-9]+)*m" => ""))
 
 function apply_expand_tabs(text::AbstractString, i0::Int)
     out_buf = IOBuffer()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,7 +355,7 @@ R = Base.text_colors[:reverse]
 r = N * Base.text_colors[:red]
 b = N * U * Base.text_colors[:light_blue]
 y = N * B * Base.text_colors[:light_yellow]
-m = N * B * R * Base.text_colors[:light_magenta]
+m = N * B * R * Base.text_colors[134]
 
 etext = """
     Julia is a $(r)high-level$(N), $(b)$(B)high$(b)-performance$(N) dynamic programming language


### PR DESCRIPTION
Now also recognizes things like `"\e[38;5;134m"`.