### PR TITLE
Fixes in the replace_whitespace=false case

### DIFF
--- a/src/TextWrap.jl
+++ b/src/TextWrap.jl
@@ -222,7 +222,8 @@ The behaviour can be controlled via optional keyword arguments:
   fit in any line. If `true`, the word will be broken, otherwise it will go beyond the desired text
   width.
 * `replace_whitespace` (default=`true`): if this flag is `true`, all whitespace characters in the
-  original text (including newlines) will be replaced by spaces.
+  original text (including newlines) will be replaced by spaces. Otherwise, they'll be preserved,
+  except at the beginning or end of a line.
 * `expand_tabs` (default=`true`): if this flag is `true`, tabs will be expanded in-place into
   spaces. Otherwise a tab is counted as a single character. The expansion happens before whitespace
   replacement.
@@ -289,8 +290,17 @@ function wrap(text::AbstractString;
             soh = "  "
         end
         if p.rep_white
-            soh = replace(soh, "\n"=>"")
+            soh = replace(soh, r"\r?\n"=>"")
             soh = isempty(soh) ? " " : " "^length(soh)
+        else
+            while (fnl = findfirst(==('\n'), soh)) ≢ nothing # using the `==` form to support julia 1.0-1.2
+                ind = s.cln == 1 ? p.iind : p.sind
+                print(out_str, ind, '\n')
+                s.cll = 0
+                s.cln += 1
+                s.bol = true
+                soh = soh[nextind(soh, fnl):end]
+            end
         end
         s.soh = soh
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,24 +100,30 @@ tabtext = "aaaaaaa\tbbbbbbb\t\ncccccc\tddddd\teeee  \tfff\tgg\th\n"
 @test wrap(tabtext, width=20, replace_whitespace=true,  expand_tabs=true) ==
     "aaaaaaa bbbbbbb\ncccccc  ddddd   eeee\nfff     gg      h"
 @test wrap(tabtext, width=20, replace_whitespace=false, expand_tabs=true) ==
-    "aaaaaaa bbbbbbb\ncccccc  ddddd   eeee\nfff     gg      h"
+    "aaaaaaa bbbbbbb\ncccccc  ddddd   eeee\nfff     gg      h\n"
 @test wrap(tabtext, width=20, replace_whitespace=true,  expand_tabs=false) ==
     "aaaaaaa bbbbbbb\ncccccc ddddd eeee\nfff gg h"
 @test wrap(tabtext, width=20, replace_whitespace=false, expand_tabs=false) ==
-    "aaaaaaa\tbbbbbbb\ncccccc\tddddd\teeee\nfff\tgg\th"
+    "aaaaaaa\tbbbbbbb\ncccccc\tddddd\teeee\nfff\tgg\th\n"
+
+@test wrap("abc\ndefg h i j k", width=8, replace_whitespace=false) ==
+           "abc\ndefg h i\nj k"
+@test wrap("abc\ndefg h i j k", width=8, replace_whitespace=true) ==
+           "abc defg\nh i j k"
 
 @test wrap("\t.\n\t\n") == "."
 @test wrap("\t..\n\t\n", fix_sentence_endings=true) == ".."
 @test wrap("\tabc\n\t\n", width=2, expand_tabs=false) == "ab\nc"
 @test wrap("\t \tabc\n\t\n", width=2) == "ab\nc"
 @test wrap("\ta.\n\t\n", width=1, fix_sentence_endings=false) == "a\n."
-@test wrap("\ta.\n\t\n", width=1, replace_whitespace=false) == "a\n."
-@test wrap("\ta.\tb\n", width=8, expand_tabs=true, replace_whitespace=false) == "a.\nb"
-@test wrap("\ta.\tb\n", width=8, expand_tabs=false, replace_whitespace=false) == "a.\tb"
-@test wrap("\ta.\tb\n", width=9, expand_tabs=false, replace_whitespace=false) == "a.\tb"
-@test wrap("\ta.\tb\n", width=9, expand_tabs=true, replace_whitespace=false) == "a.      b"
-@test wrap("\ta.\tb\n", width=9, expand_tabs=false, replace_whitespace=false, fix_sentence_endings=true) == "a.\tb"
-@test wrap("\ta.\tb\n", width=9, expand_tabs=true, replace_whitespace=false, fix_sentence_endings=true) == "a.      b"
+@test wrap("\ta.\n\t\n", width=1, replace_whitespace=false) == "a\n.\n\n"
+@test wrap("\ta.\tb\n", width=8, expand_tabs=true, replace_whitespace=true) == "a.\nb"
+@test wrap("\ta.\tb\n", width=8, expand_tabs=true, replace_whitespace=false) == "a.\nb\n"
+@test wrap("\ta.\tb\n", width=8, expand_tabs=false, replace_whitespace=false) == "a.\tb\n"
+@test wrap("\ta.\tb\n", width=9, expand_tabs=false, replace_whitespace=false) == "a.\tb\n"
+@test wrap("\ta.\tb\n", width=9, expand_tabs=true, replace_whitespace=false) == "a.      b\n"
+@test wrap("\ta.\tb\n", width=9, expand_tabs=false, replace_whitespace=false, fix_sentence_endings=true) == "a.\tb\n"
+@test wrap("\ta.\tb\n", width=9, expand_tabs=true, replace_whitespace=false, fix_sentence_endings=true) == "a.      b\n"
 
 end # testset
 


### PR DESCRIPTION
It's now aware of newlines in the original text's
whitespace.

It also keeps newlines at the end if they are given.